### PR TITLE
Fix WAAM dataset label handling

### DIFF
--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -357,7 +357,8 @@ class WAAMSegLoader(object):
         test_values = np.nan_to_num(test_values)
         self.test = self.scaler.transform(test_values)
         self.val = self.test
-        self.test_labels = np.ones(len(self.test))
+        labels = abnormal_df.get("label", pd.Series(["Normal"] * len(abnormal_df)))
+        self.test_labels = (labels != "Normal").astype(int).values
 
     def __len__(self):
         if self.mode == "train":
@@ -376,7 +377,7 @@ class WAAMSegLoader(object):
             label = np.zeros(self.win_size)
         elif self.mode == "val":
             window = self.val[start : start + self.win_size]
-            label = np.zeros(self.win_size)
+            label = self.test_labels[start : start + self.win_size]
         elif self.mode == "test":
             window = self.test[start : start + self.win_size]
             label = self.test_labels[start : start + self.win_size]


### PR DESCRIPTION
## Summary
- Properly parse labels in WAAMSegLoader so that 'Normal' rows are treated as normal and others as anomalies
- Use true labels during validation instead of zeros

## Testing
- `pytest`
- `python incremental_experiment.py --dataset WAAM --data_path WAAM_data --batch_size 256 --input_c 6 --output_c 6 --anomaly_ratio 0.5` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a7376b0c988323ba5dc7da38f13260